### PR TITLE
updates for functional programming section

### DIFF
--- a/docs/slides.adoc
+++ b/docs/slides.adoc
@@ -1694,7 +1694,7 @@ Functions always return a value
 
 * Not a pure function
 * Returns a useful result, but changes every time
-* Modifying a hidden state
+* Modifying a hidden state (or based on it)
 
 == Side effects
 
@@ -1720,12 +1720,23 @@ Functions always return a value
 * `conj` returns a new vector value
 
 
-== Persistent data structures
+== Persistent immutable data structures
 
 * Clojure implements efficient immutable data structures
 * Creating derivative values is cheap
 * Using a Java vector would require duplicating the vector
 * Clojure uses shared structure
+
+[NOTE.speaker]
+--
+Persistent + Immutable FTW!
+
+- Just immutable w/o persistent in Java - Guava collections (nice, but add/
+remote ops deprecated b/c of performance reasons)
+- Just persistent w/o immutable in Java - no popular, solid solutions. Perhaps
+less a problem for complex bugs in the wild than immutability, if you had to
+choose one but not the other.
+--
 
 
 == Pure functions are desirable


### PR DESCRIPTION
Minor edits here on Ch 6 - Functional Programming.

Also, I don't have edits in this PR here for the following point -- your exercises for this chapter rely heavily on `iterate`, but that's not brought up in the chapter.  Exercise for the author: how do you solve those problems without iterate?  (Doable, in theory.)  More seriously, it might be better to defer those exercises in favor of something more related to map, reduce, and/or filter.

Also, maybe have an exercise to just rewrite an existing super nested expression using a threading macro, since the topic was covered? Ex, when already given:
```
(defn count-i-before-e
  [s]
  (count (filter #(= % [\i \e]) (partition 2 1 (seq s)))))
```
Try: `(count-i-before-e "sieve")` and `(count-i-before-e "seize")`  Now rewrite using thread-last macro (->>):

```
(defn count-i-before-e
  [s]
  (->> s
       seq
       (partition 2 1)
       (filter #(= % [\i \e]))
       count))
```

I think some work can go into exercises for map/reduce/filter to replace the ones using iterate, what do you think?  I would need some time to think on what to come up with ideas for that.