### PR TITLE
edits for chapter on macros, other minor edits

### DIFF
--- a/docs/slides.adoc
+++ b/docs/slides.adoc
@@ -2340,7 +2340,7 @@ You have been tasked with processing the files using the validation logic you bu
 
 Create a function that opens a file called corgi-cover-applications.csv and converts every row into a data structure and prints it.
 Next use that data structure as an input to your validation function and print the result.
-See `slurp` `line-seq` `clojure.string/split`.
+See `slurp`, `line-seq`, `clojure.string/split`.
 
 
 == Part 2:
@@ -2388,7 +2388,8 @@ rearranged
     (if (< x 2)
       (do
         (println "It's less than 2!")
-        :ok))
+        :ok)
+      nil)
 
 rearranged
 
@@ -2397,10 +2398,11 @@ rearranged
       :ok)
 
 
-== Macros
+== Macros overview
 
 * Arguments manipulated at compile time
 * Arguments not evaluated
+
 Macros allow us to extend the syntax of Clojure
 
 
@@ -2432,6 +2434,12 @@ Expansion:
 * Cannot be passed to higher order functions
 * Less useful than functions
 
+[NOTE.speaker]
+--
+* Workaround 1 to (map and ...) example: anon fn -- #(and %1 %2)
+* Workaround 2 to (map and ...) example: anon fn -- #(every? identity %&)
+--
+
 
 == Defining macros
 
@@ -2462,7 +2470,7 @@ vs
 --
 
 
-== Macros
+== Macros as seen by REPL
 
 * Have a `:macro` flag set in metadata
 * Passed the input forms unevaluated


### PR DESCRIPTION
The main change here is to ensure that slide titles are all distinct.  When multiple occurrences of a slide title exists (ex: A1 B C A2 D ...), the HTML presentation script gets confused and always navigates back to the first occurrence (ex: advancing to next slide after C goes straight to A1), effectively creating a dead-end in navigation.