### PR TITLE
Update - Fixed link in manual.adoc

### DIFF
--- a/docs/manual.adoc
+++ b/docs/manual.adoc
@@ -96,7 +96,7 @@ The following software must be installed on your laptop prior to the course:
 
 === Required preparation
 
-Complete the first 10 exercises on the 4Clojure website (http://www.4clojure.com).
+Complete the first 10 exercises on the 4Clojure website (https://4clojure.oxal.org).
 
 
 === Optional reading


### PR DESCRIPTION
This change fixes #23 by updating the link in question (The original 4clojure site had shut down).